### PR TITLE
Bugfix: Fixing Undefined bindings when deleting policy

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -48,12 +48,12 @@ class KnexAdapter {
   createPolicy(ptype, rule) {
     return {
       ptype,
-      v0: rule[0] ? rule[0] : null,
-      v1: rule[1] ? rule[1] : null,
-      v2: rule[2] ? rule[2] : null,
-      v3: rule[3] ? rule[3] : null,
-      v4: rule[4] ? rule[4] : null,
-      v5: rule[5] ? rule[5] : null
+      v0: typeof rule[0] !== 'undefined' ? rule[0] : null,
+      v1: typeof rule[1] !== 'undefined' ? rule[1] : null,
+      v2: typeof rule[2] !== 'undefined' ? rule[2] : null,
+      v3: typeof rule[3] !== 'undefined' ? rule[3] : null,
+      v4: typeof rule[4] !== 'undefined' ? rule[4] : null,
+      v5: typeof rule[5] !== 'undefined' ? rule[5] : null
     };
   }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -48,12 +48,12 @@ class KnexAdapter {
   createPolicy(ptype, rule) {
     return {
       ptype,
-      v0: rule[0],
-      v1: rule[1],
-      v2: rule[2],
-      v3: rule[3],
-      v4: rule[4],
-      v5: rule[5]
+      v0: rule[0] ? rule[0] : null,
+      v1: rule[1] ? rule[1] : null,
+      v2: rule[2] ? rule[2] : null,
+      v3: rule[3] ? rule[3] : null,
+      v4: rule[4] ? rule[4] : null,
+      v5: rule[5] ? rule[5] : null
     };
   }
 

--- a/lib/adapter.test.js
+++ b/lib/adapter.test.js
@@ -1,0 +1,66 @@
+const KnexAdapter = require('./adapter.js');
+const knex = require('knex');
+const mockKnex = require('mock-knex');
+const tracker = mockKnex.getTracker();
+
+function createMockPolicy(policyValues, roleValues) {
+  // Don't alter passed values
+  policyValues = [...policyValues];
+  roleValues = [...roleValues];
+  // Fill in missing values: v0 - v5
+  for (let index = 0; index < 6; index++) {
+    if (typeof policyValues[index] === 'undefined') {
+      policyValues[index] = null;
+    }
+
+    if (typeof roleValues[index] === 'undefined') {
+      roleValues[index] = null;
+    }
+  }
+
+  return {
+    model: new Map([
+      [
+        'p',
+        new Map([
+          [
+            'p',
+            {
+              policy: [policyValues]
+            }
+          ]
+        ])
+      ],
+      ['g', new Map([['g', { policy: [roleValues] }]])]
+    ])
+  };
+}
+
+describe('adapter.js', () => {
+  let knexAdapter;
+  let database;
+  let policies;
+
+  beforeAll(async () => {
+    database = knex({
+      client: 'mysql'
+    });
+    mockKnex.mock(database);
+    knexAdapter = await KnexAdapter.newAdapter(database);
+    policies = database('policies');
+  });
+
+  /**
+   * @bugfix: https://github.com/sarneeh/casbin-knex-adapter/issues/1
+   * @fix adding ternary key checks to KnexAdapter.createPolicy(ptype, rule)
+   */
+  test('removePolicy (Bugfix: undefined v3, v4, v5 columns)', async () => {
+    const mockPolicy = ['policyName', 'domain', 'object', 'permission'];
+    const mockRole = ['userId', 'policyName', 'domain'];
+    const mockPolicyAndRole = createMockPolicy(mockPolicy, mockRole);
+    await knexAdapter.savePolicy(mockPolicyAndRole);
+
+    // Error seemed to have happened when not passing all v0 - v5 values
+    await knexAdapter.removePolicy('some string', ...['g', [...mockRole]]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
   "dependencies": {
     "casbin": "^2.0.1",
     "knex": "^0.16.5"
+  },
+  "devDependencies": {
+    "jest": "^25.1.0",
+    "mock-knex": "^0.4.7"
   }
 }


### PR DESCRIPTION
# Overview
Fixing a bug causing a knex "Undefined bindings" error from being thrown when deleting a policy

Error:
![image](https://user-images.githubusercontent.com/8643571/72356570-75b60680-36b7-11ea-8c57-cbaba5a75d5d.png)

# Changelog
### Added
- Dev dependecies
> jest
> mock-knex
- adapter.test.js
### Changed
- Added a typeof check when constructing a policy in KnexAdapter.createPolicy
